### PR TITLE
Support for "kid" (Key ID) lookups

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -20,6 +20,32 @@ func ExampleToken_decode() {
 	}
 }
 
+func ExampleToken_kid() {
+	str := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik15S2V5In0.eyJpc3MiOiJNeUlzc3VlciIsInNjb3BlcyI6WyJteV9zY29wZSJdfQ.blumu_NqfxUpTLAM48lAusGjJx5Mfyv_bRiRDWfPM9A"
+
+	KeyLookupCallback = func(kid string) Algorithm {
+		if kid == "MyKey" {
+			return HS256
+		}
+
+		return ""
+	}
+
+	secret := []byte("secret")
+	token, err := DecodeToken(str, None, secret)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := token.Verify("MyIssuer", "", ""); err != nil {
+		panic(err)
+	}
+
+	for k, v := range token.Claims {
+		fmt.Printf("%s = %v", k, v)
+	}
+}
+
 func ExampleToken_sign() {
 	token := NewToken()
 

--- a/jwt.go
+++ b/jwt.go
@@ -98,7 +98,17 @@ var (
 
 	// ErrNoneAlgorithmWithSecret is returned when the "none" algorithm is used with a secret.
 	ErrNoneAlgorithmWithSecret = errors.New("jwt: none algorithm with secret")
+
+	// ErrNoKeyProvided is returned when the key lookup callback is set, but no key is in the token.
+	ErrNoKeyProvided = errors.New("jwt: no key provided")
+
+	// ErrNonExistantKey is returned when the provided key ID does not exist.
+	ErrNonExistantKey = errors.New("jwt: non-existant key")
 )
+
+// KeyLookupCallback is used by DecodeToken to look up the algorithm to decode with
+// if the "kid" header is specified in the token.
+var KeyLookupCallback func(string) Algorithm
 
 // supportedTypes is used to determine if a token type is supported.
 var supportedTypes = map[Type]bool{

--- a/token.go
+++ b/token.go
@@ -277,8 +277,11 @@ func (t Token) Expired() bool {
 func (t Token) buildHeader() map[string]interface{} {
 	header := make(map[string]interface{})
 
-	header["typ"] = "JWT"
+	header["typ"] = t.Type
 	header["alg"] = t.Algorithm
+	if len(t.KeyID) > 0 {
+		header["kid"] = t.KeyID
+	}
 
 	return header
 }


### PR DESCRIPTION
Adds a global callback to get the algorithm from the key ID (kid) header of a token.
